### PR TITLE
Set payment minimum for credit card

### DIFF
--- a/src/CommunityStore/Payment/Methods/CommunityStoreAuthorizeNet/CommunityStoreAuthorizeNetPaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreAuthorizeNet/CommunityStoreAuthorizeNetPaymentMethod.php
@@ -273,6 +273,11 @@ class CommunityStoreAuthorizeNetPaymentMethod extends StorePaymentMethod
     {
         return $this->getPaymentMethodName();
     }
+    
+    public function getPaymentMinimum() {
+        return 0.01;
+    }
+
 
 }
 


### PR DESCRIPTION
It doesn't make sense to show the payment method for $0 orders(e.g., fully discounted), the gateway will just reject those